### PR TITLE
docs: Fix a few typos

### DIFF
--- a/Chapter02/AnimSpriteComponent.h
+++ b/Chapter02/AnimSpriteComponent.h
@@ -13,7 +13,7 @@ class AnimSpriteComponent : public SpriteComponent
 {
 public:
 	AnimSpriteComponent(class Actor* owner, int drawOrder = 100);
-	// Update animation every frame (overriden from component)
+	// Update animation every frame (overridden from component)
 	void Update(float deltaTime) override;
 	// Set the textures used for animation
 	void SetAnimTextures(const std::vector<SDL_Texture*>& textures);

--- a/Chapter02/BGSpriteComponent.h
+++ b/Chapter02/BGSpriteComponent.h
@@ -15,7 +15,7 @@ class BGSpriteComponent : public SpriteComponent
 public:
 	// Set draw order to default to lower (so it's in the background)
 	BGSpriteComponent(class Actor* owner, int drawOrder = 10);
-	// Update/draw overriden from parent
+	// Update/draw overridden from parent
 	void Update(float deltaTime) override;
 	void Draw(SDL_Renderer* renderer) override;
 	// Set the textures used for the background

--- a/Chapter07/SoundEvent.h
+++ b/Chapter07/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter09/SoundEvent.h
+++ b/Chapter09/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter10/PhysWorld.h
+++ b/Chapter10/PhysWorld.h
@@ -26,7 +26,7 @@ public:
 		Vector3 mNormal;
 		// Component collided with
 		class BoxComponent* mBox;
-		// Owning actor of componnet
+		// Owning actor of component
 		class Actor* mActor;
 	};
 

--- a/Chapter10/SoundEvent.h
+++ b/Chapter10/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter11/PhysWorld.h
+++ b/Chapter11/PhysWorld.h
@@ -26,7 +26,7 @@ public:
 		Vector3 mNormal;
 		// Component collided with
 		class BoxComponent* mBox;
-		// Owning actor of componnet
+		// Owning actor of component
 		class Actor* mActor;
 	};
 

--- a/Chapter11/SoundEvent.h
+++ b/Chapter11/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter12/PhysWorld.h
+++ b/Chapter12/PhysWorld.h
@@ -26,7 +26,7 @@ public:
 		Vector3 mNormal;
 		// Component collided with
 		class BoxComponent* mBox;
-		// Owning actor of componnet
+		// Owning actor of component
 		class Actor* mActor;
 	};
 

--- a/Chapter12/SoundEvent.h
+++ b/Chapter12/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter13/PhysWorld.h
+++ b/Chapter13/PhysWorld.h
@@ -26,7 +26,7 @@ public:
 		Vector3 mNormal;
 		// Component collided with
 		class BoxComponent* mBox;
-		// Owning actor of componnet
+		// Owning actor of component
 		class Actor* mActor;
 	};
 

--- a/Chapter13/Renderer.cpp
+++ b/Chapter13/Renderer.cpp
@@ -444,7 +444,7 @@ void Renderer::DrawFromGBuffer()
 	// Set the point light shader and mesh as active
 	mGPointLightShader->SetActive();
 	mPointLightMesh->GetVertexArray()->SetActive();
-	// Set the view-projeciton matrix
+	// Set the view-projection matrix
 	mGPointLightShader->SetMatrixUniform("uViewProj",
 		mView * mProjection);
 	// Set the G-buffer textures for sampling

--- a/Chapter13/SoundEvent.h
+++ b/Chapter13/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter13/Texture.cpp
+++ b/Chapter13/Texture.cpp
@@ -57,7 +57,7 @@ bool Texture::Load(const std::string& fileName)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-	// Enable aniostropic filtering, if supported
+	// Enable anisotropic filtering, if supported
 	if (GLEW_EXT_texture_filter_anisotropic)
 	{
 		// Get the maximum anisotropy value

--- a/Chapter14/Actor.h
+++ b/Chapter14/Actor.h
@@ -91,7 +91,7 @@ public:
 		return t;
 	}
 
-	// Search throuch component vector for one of type
+	// Search through component vector for one of type
 	Component* GetComponentOfType(Component::TypeID type)
 	{
 		Component* comp = nullptr;

--- a/Chapter14/PhysWorld.h
+++ b/Chapter14/PhysWorld.h
@@ -26,7 +26,7 @@ public:
 		Vector3 mNormal;
 		// Component collided with
 		class BoxComponent* mBox;
-		// Owning actor of componnet
+		// Owning actor of component
 		class Actor* mActor;
 	};
 

--- a/Chapter14/Renderer.cpp
+++ b/Chapter14/Renderer.cpp
@@ -439,7 +439,7 @@ void Renderer::DrawFromGBuffer()
 	// Set the point light shader and mesh as active
 	mGPointLightShader->SetActive();
 	mPointLightMesh->GetVertexArray()->SetActive();
-	// Set the view-projeciton matrix
+	// Set the view-projection matrix
 	mGPointLightShader->SetMatrixUniform("uViewProj",
 		mView * mProjection);
 	// Set the G-buffer textures for sampling

--- a/Chapter14/SoundEvent.h
+++ b/Chapter14/SoundEvent.h
@@ -16,7 +16,7 @@ public:
 	SoundEvent();
 	// Returns true if associated FMOD event still exists
 	bool IsValid();
-	// Restart event from begining
+	// Restart event from beginning
 	void Restart();
 	// Stop this event
 	void Stop(bool allowFadeOut = true);

--- a/Chapter14/Texture.cpp
+++ b/Chapter14/Texture.cpp
@@ -58,7 +58,7 @@ bool Texture::Load(const std::string& fileName)
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 
-	// Enable aniostropic filtering, if supported
+	// Enable anisotropic filtering, if supported
 	if (GLEW_EXT_texture_filter_anisotropic)
 	{
 		// Get the maximum anisotropy value

--- a/Errata.md
+++ b/Errata.md
@@ -10,7 +10,7 @@ please create an issue on this GitHub repository.
   - Page 70: When discussing the properties of the dot product, the text incorrectly states
     that the dot product is associative. It is not associative since the first dot
 	 product results in a scalar, and thus it is impossible to perform a second dot product. However,
-	 scalar multiplication is assocaitive over the dot product, since s (a dot b) = (s a) dot b.
+	 scalar multiplication is associative over the dot product, since s (a dot b) = (s a) dot b.
 	 (found by Takashi Imagire)
 * Chapter 4
   - Page 101: The last sentence should read "In this case, if you access outMap and the node requested


### PR DESCRIPTION
There are small typos in:
- Chapter02/AnimSpriteComponent.h
- Chapter02/BGSpriteComponent.h
- Chapter07/SoundEvent.h
- Chapter09/SoundEvent.h
- Chapter10/PhysWorld.h
- Chapter10/SoundEvent.h
- Chapter11/PhysWorld.h
- Chapter11/SoundEvent.h
- Chapter12/PhysWorld.h
- Chapter12/SoundEvent.h
- Chapter13/PhysWorld.h
- Chapter13/Renderer.cpp
- Chapter13/SoundEvent.h
- Chapter13/Texture.cpp
- Chapter14/Actor.h
- Chapter14/PhysWorld.h
- Chapter14/Renderer.cpp
- Chapter14/SoundEvent.h
- Chapter14/Texture.cpp
- Errata.md

Fixes:
- Should read `beginning` rather than `begining`.
- Should read `component` rather than `componnet`.
- Should read `projection` rather than `projeciton`.
- Should read `overridden` rather than `overriden`.
- Should read `anisotropic` rather than `aniostropic`.
- Should read `through` rather than `throuch`.
- Should read `associative` rather than `assocaitive`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md