### PR TITLE
added <algorithm> and <limits> includes

### DIFF
--- a/Chapter04/Search.cpp
+++ b/Chapter04/Search.cpp
@@ -2,6 +2,8 @@
 #include <queue>
 #include <iostream>
 #include <unordered_map>
+#include <algorithm>
+#include <limits>
 
 struct GraphNode
 {


### PR DESCRIPTION
The use of std::numeric_limits, std::min_element(), std::min(), and std::max, require the inclusion of "algorithm" and "limits"

(my first pull request so if I'm doing this wrong I apologize.) 