### PR TITLE
Fix bug in Chapter2/BGSpriteComponent.cpp

### DIFF
--- a/Chapter02/BGSpriteComponent.cpp
+++ b/Chapter02/BGSpriteComponent.cpp
@@ -26,7 +26,7 @@ void BGSpriteComponent::Update(float deltaTime)
 		// the right of the last bg texture
 		if (bg.mOffset.x < -mScreenSize.x)
 		{
-			bg.mOffset.x = (mBGTextures.size() - 1) * mScreenSize.x - 1;
+			bg.mOffset.x += mScreenSize.x * mBGTextures.size();
 		}
 	}
 }


### PR DESCRIPTION
I found a bug in Update BGSpriteComponent.cpp and suggest fix of its. The bug:
```cpp
bg.mOffset.x = (mBGTextures.size() - 1) * mScreenSize.x - 1;
```
If mScrollSpeed will high, for example 600, it makes gap between two background. Cause `-1`  at the end of the formula is hack that makes sense only when mScrollSpeed is low.
<img width="256" alt="image" src="https://github.com/gameprogcpp/code/assets/33521581/a29e1ff7-af9a-4f84-877d-b3e6adba6ab6">

My fix keeps diff between bg.mOffset.x and width, if it more than 1px.
```cpp
bg.mOffset.x += mScreenSize.x * mBGTextures.size();
```